### PR TITLE
Issue#8:

### DIFF
--- a/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/Claimbuild.java
+++ b/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/Claimbuild.java
@@ -3,6 +3,8 @@ package org.example.Entitys;
 import jakarta.persistence.*;
 import org.example.Enums.ClaimbuildType;
 
+import java.util.Set;
+
 @Entity
 public class Claimbuild {
     @Id
@@ -27,6 +29,8 @@ public class Claimbuild {
     @JoinColumn(name="controllingFaction", nullable = false)
     private Faction controllingFaction;
 
+    @OneToMany(mappedBy = "claimbuild")
+    Set<UsedProductionSite> productionSites;
 
     public Claimbuild() {
     }

--- a/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/ProdSite.java
+++ b/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/ProdSite.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import org.example.Enums.ProductionSideType;
 import org.example.Enums.Resource;
 
+import java.util.Set;
+
 @Entity
 public class ProdSite {
     @Id
@@ -11,16 +13,14 @@ public class ProdSite {
     private int id;
     @Enumerated(EnumType.STRING)
     private ProductionSideType type;
-    private Resource resource;
-    private int amount;
+    @OneToMany(mappedBy = "productionSite")
+    private Set<UsedProductionSite> usingClaimbuilds;
 
     public ProdSite() {
     }
 
-    public ProdSite(ProductionSideType type, Resource resource, int amount) {
+    public ProdSite(ProductionSideType type) {
         this.type = type;
-        this.resource = resource;
-        this.amount = amount;
     }
 
     public int getId() {
@@ -31,23 +31,7 @@ public class ProdSite {
         return type;
     }
 
-    public Resource getResource() {
-        return resource;
-    }
-
-    public int getAmount() {
-        return amount;
-    }
-
     public void setType(ProductionSideType type) {
         this.type = type;
-    }
-
-    public void setResource(Resource resource) {
-        this.resource = resource;
-    }
-
-    public void setAmount(int amount) {
-        this.amount = amount;
     }
 }

--- a/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/UsedProductionSite.java
+++ b/Software/AL_Systems_DB2/src/main/java/org/example/Entitys/UsedProductionSite.java
@@ -1,0 +1,23 @@
+package org.example.Entitys;
+
+import jakarta.persistence.*;
+import org.example.Enums.Resource;
+
+@Entity
+public class UsedProductionSite {
+    @Id
+    @GeneratedValue
+    private int id;
+
+    @ManyToOne
+    @JoinColumn(name = "claimbuild_ID")
+    private Claimbuild claimbuild;
+
+    @ManyToOne
+    @JoinColumn(name = "productionSite_ID")
+    private ProdSite productionSite;
+
+    private Resource resource;
+
+    private int amount;
+}


### PR DESCRIPTION
Relation Claimbuild has Production Site mit eigener Entität gelöst. Grund dafür: Ein Claimbuild kann die gleiche Production Site mehrfach nutzen (ein Claimbuild kann 2 Quarrys haben) und dann wäre der CompositeKey nicht mehr eindeutig, deswegen muss eine eigene Entität her